### PR TITLE
Fixed NameError due to typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.5'
+version = '1.0.5.1'
 
 setup(
     name='userapp',

--- a/userapp/__init__.py
+++ b/userapp/__init__.py
@@ -223,7 +223,7 @@ class Client(object):
         if sys.version_info[0] < 3:
             encoded_credentials=base64.b64encode('{u}:{p}'.format(u=self._app_id, p=self._token)).encode('ascii')
         else:
-            encoded_credentials=base64.b64encode(byte('{u}:{p}'.format(u=self._app_id, p=self._token), 'ascii')).decode('ascii')
+            encoded_credentials=base64.b64encode(bytes('{u}:{p}'.format(u=self._app_id, p=self._token), 'ascii')).decode('ascii')
 
         response = self._transport.call(
             'post',


### PR DESCRIPTION
For using "bytes" object, we need to use bytes built-in functions in python 3, not byte.
